### PR TITLE
h2c: add Server & Dialer types

### DIFF
--- a/h2c/dialer.go
+++ b/h2c/dialer.go
@@ -1,0 +1,78 @@
+package h2c
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Dialer connects to a HTTP 1.1 server and performs an h2c upgrade to an HTTP2 connection.
+type Dialer struct {
+	Dialer *net.Dialer
+	URL    *url.URL
+}
+
+// DialContext connects to the address on the named network using the provided context.
+func (d Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialfn := http.DefaultTransport.(*http.Transport).DialContext
+	if d.Dialer != nil && d.Dialer.DialContext != nil {
+		dialfn = d.Dialer.DialContext
+	}
+
+	conn, err := dialfn(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	u := "http://" + addr
+	if d.URL != nil {
+		u = d.URL.String()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "h2c")
+
+	if err := req.Write(conn); err != nil {
+		return nil, err
+	}
+
+	res, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusSwitchingProtocols {
+		return nil, errors.New("h2c upgrade failed, recieved non 101 response")
+	}
+	if strings.ToLower(res.Header.Get("Connection")) != "upgrade" {
+		return nil, errors.New("h2c upgrade failed, bad Connection header in response")
+	}
+	if strings.ToLower(res.Header.Get("Upgrade")) != "h2c" {
+		return nil, errors.New("h2c upgrade failed, bad Upgrade header in response")
+	}
+	if buf, err := ioutil.ReadAll(res.Body); len(buf) > 0 || err != nil {
+		return nil, errors.New("h2c upgrade failed, upgrade response body was non empty")
+	}
+
+	return conn, nil
+}
+
+// Dial connects to the address on the named network.
+func (d Dialer) Dial(network, addr string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, addr)
+}
+
+// DialGRPC connects to the address before timeout.
+func (d Dialer) DialGRPC(addr string, timeout time.Duration) (net.Conn, error) {
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	return d.DialContext(ctx, "tcp", addr)
+}

--- a/h2c/end2end_test.go
+++ b/h2c/end2end_test.go
@@ -1,0 +1,68 @@
+package h2c
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc"
+
+	"github.com/lstoll/grpce/helloproto"
+)
+
+type helloH2C struct{}
+
+func (helloH2C) HelloWorld(ctx context.Context, _ *helloproto.HelloRequest) (*helloproto.HelloResponse, error) {
+	return &helloproto.HelloResponse{
+		Message:    "Hello over h2c!",
+		ServerName: "h2c",
+	}, nil
+}
+
+func TestEnd2End(t *testing.T) {
+	http2.DebugGoroutines = true
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := grpc.NewServer()
+	helloproto.RegisterHelloServer(s, helloH2C{})
+
+	srv := &Server{
+		HTTP2Handler:      s,
+		NonUpgradeHandler: http.HandlerFunc(http.NotFound),
+	}
+
+	go http.Serve(ln, srv)
+
+	for {
+		if conn, err := net.Dial("tcp", ln.Addr().String()); err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	conn, err := grpc.Dial(ln.Addr().String(), grpc.WithDialer(Dialer{}.DialGRPC), grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := helloproto.NewHelloClient(conn)
+
+	res, err := c.HelloWorld(context.Background(), new(helloproto.HelloRequest))
+	if err != nil {
+		t.Error(err)
+	}
+	if want, got := "Hello over h2c!", res.Message; want != got {
+		t.Errorf("want response message %q, got %q", want, got)
+	}
+	if want, got := "h2c", res.ServerName; want != got {
+		t.Errorf("want server name %q, got %q", want, got)
+	}
+}

--- a/h2c/server.go
+++ b/h2c/server.go
@@ -1,0 +1,80 @@
+package h2c
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/http2"
+)
+
+// Server is an HTTP 1.1 server that can detect h2c upgrades and serve them by
+// an HTTP2 handler.
+type Server struct {
+	HTTP2Handler      http.Handler
+	NonUpgradeHandler http.Handler
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	connection, upgrade := r.Header.Get("Connection"), r.Header.Get("Upgrade")
+
+	if !isH2C(connection, upgrade) {
+		s.NonUpgradeHandler.ServeHTTP(w, r)
+		return
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Connection", "Upgrade")
+	w.Header().Set("Upgrade", "h2c")
+	w.WriteHeader(http.StatusSwitchingProtocols)
+
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	new(http2.Server).ServeConn(bufConn{conn, bufrw}, &http2.ServeConnOpts{
+		Handler: s.HTTP2Handler,
+	})
+}
+
+func isH2C(connection, upgrade string) bool {
+	connection, upgrade = strings.ToLower(connection), strings.ToLower(upgrade)
+	return upgrade == "h2c" && (connection == "upgrade" || strings.HasPrefix(connection, "upgrade,"))
+}
+
+type bufConn struct {
+	net.Conn
+	bufrw *bufio.ReadWriter
+}
+
+func (bc bufConn) Close() error {
+	bc.bufrw.Flush()
+
+	return bc.Conn.Close()
+}
+
+func (bc bufConn) Read(p []byte) (int, error) {
+	if n := bc.bufrw.Reader.Buffered(); n > 0 {
+		return bc.bufrw.Read(p)
+	}
+
+	return bc.Conn.Read(p)
+}
+
+func (bc bufConn) Write(p []byte) (int, error) {
+	if n := bc.bufrw.Writer.Buffered(); n > 0 {
+		if err := bc.bufrw.Flush(); err != nil {
+			return 0, err
+		}
+	}
+
+	return bc.Conn.Write(p)
+}


### PR DESCRIPTION
Add Server and corresponding Dialer types for managing an h2c upgrade over a HTTP 1.1 endpoint.
