### PR TITLE
identitydoc: add Doc, Sig, & CheckSignature to InstanceIdentityDocument

### DIFF
--- a/identitydoc/identitydoc.go
+++ b/identitydoc/identitydoc.go
@@ -48,6 +48,9 @@ type InstanceIdentityDocument struct {
 	PendingTime      time.Time `json:"pendingTime"`
 	InstanceType     string    `json:"instanceType"`
 	ImageID          string    `json:"imageId"`
+
+	Doc json.RawMessage `json:"-"`
+	Sig []byte          `json:"-"`
 }
 
 // VerifyDocumentAndSignature will confirm that the document is correct by
@@ -83,5 +86,8 @@ func VerifyDocumentAndSignature(region string, document, signature []byte) (*Ins
 	if err != nil {
 		return nil, err
 	}
+	iid.Doc = document
+	iid.Sig = signature
+
 	return iid, nil
 }

--- a/identitydoc/identitydoc_test.go
+++ b/identitydoc/identitydoc_test.go
@@ -2,6 +2,7 @@ package identitydoc
 
 import (
 	"bytes"
+	"encoding/base64"
 	"testing"
 )
 
@@ -38,7 +39,12 @@ func TestDocVerification(t *testing.T) {
 	if !bytes.Equal(doc.Doc, []byte(testDoc)) {
 		t.Error("Raw document did not match input document")
 	}
-	if !bytes.Equal(doc.Sig, []byte(testSig)) {
+
+	rawSig, err := base64.StdEncoding.DecodeString(string(testSig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(doc.Sig, rawSig) {
 		t.Error("Document signature did not match input signature")
 	}
 

--- a/identitydoc/identitydoc_test.go
+++ b/identitydoc/identitydoc_test.go
@@ -1,6 +1,9 @@
 package identitydoc
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 var testSig = `Ob3mEexQi/91fA/HMqS7L1DraJ/8T/lAblai/PrSgx6FMMPpQpi2rftc/iUcs4Uufzq0NjXkwk95
 9cRES6s3T36hWgob/cutg5imhdy5++bymuzE8Z6T35pU3y3kn4eS6Yebna1atVbAFifeAqySGXCZ
@@ -30,6 +33,13 @@ func TestDocVerification(t *testing.T) {
 	}
 	if doc == nil {
 		t.Error("Test document failed auth")
+	}
+
+	if !bytes.Equal(doc.Doc, []byte(testDoc)) {
+		t.Error("Raw document did not match input document")
+	}
+	if !bytes.Equal(doc.Sig, []byte(testSig)) {
+		t.Error("Document signature did not match input signature")
 	}
 
 	mod := testDoc + "lol"


### PR DESCRIPTION
The document can't be reconstructed from the struct's fields, so add the raw document & signature in unmarshaled fields. Also add `CheckSignature() bool` helper method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lstoll/grpce/7)
<!-- Reviewable:end -->
