### PR TITLE
kvresolver: fix race condition on Close

### DIFF
--- a/kvresolver/kvresolver.go
+++ b/kvresolver/kvresolver.go
@@ -2,6 +2,7 @@ package kvresolver
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/lstoll/grpce/reporters"
@@ -20,6 +21,8 @@ type pollWatcher struct {
 	updChan       chan []*naming.Update
 	closeChan     chan struct{}
 	currAddresses []string
+
+	updatewg *sync.WaitGroup
 }
 
 type kvrOptions struct {
@@ -63,6 +66,7 @@ func (p *pollResolver) Resolve(target string) (naming.Watcher, error) {
 		updChan:       uc,
 		closeChan:     cc,
 		currAddresses: []string{},
+		updatewg:      new(sync.WaitGroup),
 	}
 
 	updateAddrs := func() error {
@@ -108,6 +112,9 @@ func (p *pollResolver) Resolve(target string) (naming.Watcher, error) {
 	}
 
 	go func() {
+		defer pw.updatewg.Done()
+		pw.updatewg.Add(1)
+
 		ticker := time.NewTicker(p.pollInterval)
 		for {
 			select {
@@ -125,13 +132,19 @@ func (p *pollResolver) Resolve(target string) (naming.Watcher, error) {
 	}()
 
 	// Initial seed. Do async to not block
-	go updateAddrs()
+	go func() {
+		defer pw.updatewg.Done()
+		pw.updatewg.Add(1)
+
+		updateAddrs()
+	}()
 
 	return pw, nil
 }
 
 func (p *pollWatcher) Close() {
 	close(p.closeChan)
+	p.updatewg.Wait()
 	close(p.updChan)
 }
 


### PR DESCRIPTION
Remove a race on Close that can cause an update to send to a closed channel.

```
panic: send on closed channel
goroutine 15 [running]:
x/vendor/github.com/lstoll/grpce/kvresolver.(*pollResolver).Resolve.func1(0xc4202bacc0, 0xc4202b85a0)
	/src/x/vendor/github.com/lstoll/grpce/kvresolver/kvresolver.go:105 +0x68f
created by x/vendor/github.com/lstoll/grpce/kvresolver.(*pollResolver).Resolve
	/src/x/vendor/github.com/lstoll/grpce/kvresolver/kvresolver.go:128 +0x1ad
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lstoll/grpce/9)
<!-- Reviewable:end -->
