### PR TITLE
Support Graceful Shutdown

### DIFF
--- a/h2c/server.go
+++ b/h2c/server.go
@@ -2,12 +2,17 @@ package h2c
 
 import (
 	"bufio"
+	"context"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"golang.org/x/net/http2"
 )
+
+const shutdownPollInterval = 500 * time.Millisecond
 
 // Server is an HTTP 1.1 server that can detect h2c upgrades and serve them by
 // an HTTP2 handler.
@@ -19,6 +24,9 @@ type Server struct {
 	// use the Upgrade header in this case. This is not to spec, but seems to
 	// work OK.
 	ALBSupport bool
+
+	connections map[net.Conn]struct{}
+	mutex       sync.Mutex
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -44,10 +52,44 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.trackConn(conn, true)
+	defer s.trackConn(conn, false)
 
 	new(http2.Server).ServeConn(bufConn{conn, bufrw}, &http2.ServeConnOpts{
 		Handler: s.HTTP2Handler,
 	})
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	ticker := time.NewTicker(shutdownPollInterval)
+	defer ticker.Stop()
+	for {
+		// TODO: This is a pretty naive approach.
+		// Just checking whether there are any connections used for requests
+		// that haven't yet finished. Hopefully it's "good enough".
+		if len(s.connections) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Server) trackConn(conn net.Conn, add bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.connections == nil {
+		s.connections = make(map[net.Conn]struct{})
+	}
+	if add {
+		s.connections[conn] = struct{}{}
+	} else {
+		delete(s.connections, conn)
+	}
 }
 
 func (s *Server) isH2C(connection, upgrade string) bool {


### PR DESCRIPTION
Unfortunately, `Server.Shutdown` in the `http` package [does not wait for hijacked connections](https://golang.org/pkg/net/http/#Server.Shutdown) to complete. Since `h2c` hijacks every connection that it upgrades, it does not allow for graceful shutdowns (there is effectively no way to wait on the hijacked connections to complete).

I've implemented a `Shutdown` function on the `h2c.Server` that simply waits for there to be no hijacked connections currently open. The caller can then shutdown the underlying `http.Server` and then shutdown the `h2c.Server` to achieve graceful shutdown.